### PR TITLE
Windows issue hotfix

### DIFF
--- a/usim800/Communicate.py
+++ b/usim800/Communicate.py
@@ -4,14 +4,10 @@ import re
 import json
 
 class communicate:
-    TIMMEOUT = 1
     cmd_list = []
 
-    def __init__(self, baudrate, path):
-        self._baudrate = baudrate
-        self._path = path
-        self._port = serial.Serial(path, baudrate=baudrate,
-                                  timeout=communicate.TIMMEOUT)
+    def __init__(self, port):
+        self._port = port
 
     def _setcmd(self, cmd, end='\r\n'):
         end = '\r\n'

--- a/usim800/usim800.py
+++ b/usim800/usim800.py
@@ -3,11 +3,15 @@ from usim800.Sms import sms
 from usim800.Communicate import  communicate
 from usim800.Request import request
 from usim800.Info import info
+import serial
 
 class sim800(communicate):
+    TIMMEOUT = 1
+
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.requests = request(baudrate=self._baudrate,path=self._path)
-        self.info = info(baudrate=self._baudrate,path=self._path)
-        self.sms = sms(baudrate=self._baudrate,path=self._path)
+        self.port = serial.Serial(path, baudrate=baudrate, timeout=sim800.TIMMEOUT)
+        super().__init__(self.port)
+        self.requests = request(self.port)
+        self.info = info(self.port)
+        self.sms = sms(self.port)
 


### PR DESCRIPTION
The serialport is now opened a single time and passed as a reference to the other objects.
I tested it and I was able to send a message successfully. 

It is a quick hotfix I made in order to get it to work, feel free to change it.